### PR TITLE
Update broken link to ardumont's init file

### DIFF
--- a/bindings.md
+++ b/bindings.md
@@ -94,4 +94,4 @@ For example, installing using the <kbd>C-c x</kbd> as prefix key:
 
 *Note* If org-trello was already running, you will need to relaunch the mode (<kbd>M-x org-trello-mode</kbd> twice).
 
-For example, here is my [startup file](https://github.com/ardumont/orgmode-pack/blob/master/init.el#L3).
+For example, here is my [startup file](https://github.com/ardumont/orgmode-pack/blob/master/orgmode-pack.el#L57).


### PR DESCRIPTION
I am not sure if this is correct, but at least it is not a broken link.

Specifically, I was looking for a thorough example of a `custom-set-variables` configuration for `org-trello`. I couldn't find it under the orgmode-pack, but maybe it is under the `org-trello-tools.el` file on that new link here: https://github.com/ardumont/orgmode-pack/blob/master/orgmode-pack.el#L57

Perhaps we can make a link instead to your org-trello-tools.el file?

In my case, I was trying to do the following: 
`(custom-set-variables '(org-trello-files '("~/Documents/mgmt-docs/*.trello") ))`
although it only works on the following:
`(custom-set-variables '(org-trello-files '("~/Documents/mgmt-docs/calendar.trello") ))`

Anyway, I hope this helps!
